### PR TITLE
references #32, supports basescript with structlog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,30 @@
 language: python
 python:
-    - "2.7"
-install: "pip install ."
+  - "2.7"
+install: 
+  # TODO is there a different way to get pandoc ?
+  - "sudo apt-get install pandoc"
+  - "pip install pypandoc"
+  - "pip install ."
 script: 
-    - echo "no tests yet"
+  - echo "no tests yet"
+deploy:
+  # test pypi
+  - provider: pypi
+    distributions: "sdist bdist_wheel"
+    server: https://testpypi.python.org/pypi
+    user: "deepcompute"
+    password:
+      secure: "Q1ziL0arTF7kn70hBLi77MJaoU4QfYOVbcqMD1RC8tcVCVmKfzrTAf2GbvQnmVgKqlRFugv1gQPocWniJ0XmSAjFcZxECdjdkDyk6/8Cq2jfmKZrWCEMj6OcB+m0wV225CrYbcKfwMGef6MPK2cFr0IT/f4i+JgpA6FhfXYYgsVJtML3UaqbQPieXTM1g3U9SbntV+AvHfulCJZJ4dLlXZwjEFAYnF8xb4bZmWEsHjqgXX8Abvxgo9OCMkypO6BVQoppY+J4EoZIBIA/x93PHFODF+TVp88S2FUlB9Uvy9FchoWup9zRvnYa4SCyVN1f5PBlFLXvsErwTnwYcG5l+9Fqv19P4F3pgbaLD/H3PKf8kr7VqM/WLLY9O5UBoQot5W2TqWqSK9y3ZngT5vT6BHz3+joswHA2bY6OhdkhHLiPdj5aAzQudrjuO6g/vOmQxUU1l9GFuiyM4I7+PfPTLB/Y9F3OvfxMOoxZLMtFsErNtK7gdfVlkgT7XV/gazvGKUiXBOMQ1cbssk8ojQLEyh44969aSqlq/SkPKHqVpQv98GGyLOJBC9lMbpMFEJDa5B62rbrX5SZZsekEf/6t9AUSvmHXW9jKmqxzG74oMnGlCD6fkQ1vk+6j1E+XrRY0xRmkS3sHSzSGDNEzN5Llb8KsgLWvOHww93s8F0Hy3G4="
+    on:
+      branch: master
+      tags: false
+  # pypi
+  - provider: pypi
+    distributions: "sdist bdist_wheel"
+    user: "deepcompute"
+    passsword:
+      secure: "Q1ziL0arTF7kn70hBLi77MJaoU4QfYOVbcqMD1RC8tcVCVmKfzrTAf2GbvQnmVgKqlRFugv1gQPocWniJ0XmSAjFcZxECdjdkDyk6/8Cq2jfmKZrWCEMj6OcB+m0wV225CrYbcKfwMGef6MPK2cFr0IT/f4i+JgpA6FhfXYYgsVJtML3UaqbQPieXTM1g3U9SbntV+AvHfulCJZJ4dLlXZwjEFAYnF8xb4bZmWEsHjqgXX8Abvxgo9OCMkypO6BVQoppY+J4EoZIBIA/x93PHFODF+TVp88S2FUlB9Uvy9FchoWup9zRvnYa4SCyVN1f5PBlFLXvsErwTnwYcG5l+9Fqv19P4F3pgbaLD/H3PKf8kr7VqM/WLLY9O5UBoQot5W2TqWqSK9y3ZngT5vT6BHz3+joswHA2bY6OhdkhHLiPdj5aAzQudrjuO6g/vOmQxUU1l9GFuiyM4I7+PfPTLB/Y9F3OvfxMOoxZLMtFsErNtK7gdfVlkgT7XV/gazvGKUiXBOMQ1cbssk8ojQLEyh44969aSqlq/SkPKHqVpQv98GGyLOJBC9lMbpMFEJDa5B62rbrX5SZZsekEf/6t9AUSvmHXW9jKmqxzG74oMnGlCD6fkQ1vk+6j1E+XrRY0xRmkS3sHSzSGDNEzN5Llb8KsgLWvOHww93s8F0Hy3G4="
+    on:
+      branch: master
+      tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+    - "2.7"
+install: "pip install ."
+script: 
+    - echo "no tests yet"

--- a/funcserver/templates/logs.html
+++ b/funcserver/templates/logs.html
@@ -20,7 +20,7 @@
     evt_template = _.template($("#evt_template").text());
 
     function on_message(m) {
-        m = evt_template({'evt': m['data']});
+        m = evt_template({'evt': JSON.stringify(m['data'])});
         $("#events").prepend(m);
         $("pre.evtwaiting").remove();
     };

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except:
     Make sure pypandoc is installed.
     """
 
-version = '0.2.10'
+version = '0.2.11'
 setup(
     name="funcserver",
     version=version,
@@ -28,7 +28,7 @@ setup(
         'requests',
         'tornado',
         'msgpack-python',
-        'basescript',
+        'basescript >= 0.1.6',
     ],
     package_dir={'funcserver': 'funcserver'},
     packages=find_packages('.'),


### PR DESCRIPTION
- funcserver creates a hook to send logs through the websocket.
- logs.html showcases the dictionaries properly.
    - when using stdlib, it was a string, but now since we are using
      structlog, it is a dictionary. If left untouched, it would
      display `[object][Object]`. `JSON.stringify` fixes this.
- changed setup.py to work with a basescript which supports structlog.