### PR TITLE
fixes #52, stops iteration when client disconnects

### DIFF
--- a/funcserver/funcserver.py
+++ b/funcserver/funcserver.py
@@ -416,7 +416,7 @@ class RPCHandler(BaseHandler):
                 part = next(result)
                 part = serializer(part)
                 self.write(part)
-                sep = '\n' if is_raw else self.get_record_separator(protocol)
+                sep = '' if is_raw else self.get_record_separator(protocol)
                 if sep: self.write(sep)
                 self.flush
 


### PR DESCRIPTION
for the same script in issue #52 

```python
import time
from funcserver import Server

class MyAPI(object):
    def foo(self):
        try:
            self.log.info("starting...")
            for i in xrange(10):
                self.log.info("yielding", i=i)
                yield i
                time.sleep(2.0)

        finally:
            self.log.info("cleanup...")

class MyServer(Server):
    def prepare_api(self):
        return MyAPI()

if __name__ == '__main__':
    MyServer().start()
```

```bash
python test.py run --port 8888
```

```bash
$ curl 'http://localhost:8888/rpc/json?fn=foo'
0
1
2
^C
```

> When client disconnects, stops iteration midway and performs cleanup

```bash
2017-03-27T10:16:29.238897Z [info     ] starting...                    _={'ln': 7, 'file': 'test.py', 'name': '__main__', 'fn': 'foo'}
2017-03-27T10:16:29.239013Z [info     ] yielding                       _={'ln': 9, 'file': 'test.py', 'name': '__main__', 'fn': 'foo'} i=0
2017-03-27T10:16:29.654906Z [info     ] api,fn=foo,host=ant-Dell-n411z,name=FuncServer,success=True c_invoked=1,t_duration_count=1,t_duration_lower=0.0100135803223,t_duration_mean=0.0100135803223,t_duration_sum=0.0100135803223,t_duration_upper=0.0100135803223 1490609789654 influx_metric=True
2017-03-27T10:16:31.241505Z [info     ] yielding                       _={'ln': 9, 'file': 'test.py', 'name': '__main__', 'fn': 'foo'} i=1
2017-03-27T10:16:33.244503Z [info     ] yielding                       _={'ln': 9, 'file': 'test.py', 'name': '__main__', 'fn': 'foo'} i=2
2017-03-27T10:16:35.247424Z [info     ] yielding                       _={'ln': 9, 'file': 'test.py', 'name': '__main__', 'fn': 'foo'} i=3
2017-03-27T10:16:35.263030Z [info     ] cleanup...                     _={'ln': 14, 'file': 'test.py', 'name': '__main__', 'fn': 'foo'}
2017-03-27T10:16:35.263346Z [info     ] 200 GET /rpc/json?fn=foo (127.0.0.1) 6026.45ms _={'ln': 1971, 'file': '~/.virtualenvs/funcserver/local/lib/python2.7/site-packages/tornado/web.py', 'name': 'tornado.access', 'fn': 'log_request'}
2017-03-27T10:16:41.106105Z [warning  ] exited via keyboard interrupt  _={'ln': 64, 'file': '~/.virtualenvs/funcserver/local/lib/python2.7/site-packages/basescript/basescript.py', 'name': 'basescript.basescript', 'fn': 'start'}
```