### PR TITLE
references #56, response contains common tags

### DIFF
--- a/funcserver/funcserver.py
+++ b/funcserver/funcserver.py
@@ -361,6 +361,7 @@ class RPCHandler(BaseHandler):
                 fn=fn_name, args=args, kwargs=kwargs,
             )
 
+        r.update(self.server.define_common_tags())
         return r
 
     def _handle_call(self, request, fn, m, protocol):
@@ -640,8 +641,24 @@ class Server(BaseScript):
         '''
         return None
 
+    def define_common_tags(self):
+        '''
+        Define common key value pairs as a dictionary that will be
+        part of every response to the client
+        '''
+        return {}
+
+    def _validate_common_tags(self):
+        tags = self.define_common_tags()
+        for tag in ('result', 'success'):
+            if tag not in tags: continue
+
+            self.log.warning("bad common tag", name=tag)
+
     def run(self):
         """ prepares the api and starts the tornado funcserver """
+        self._validate_common_tags()
+
         self.log_id = 0
 
         # all active websockets and their state


### PR DESCRIPTION
closes #56 
connected to #56 

As shown in the example below, regardless of success / failure, the version is mentioned

```python
from funcserver import Server

class MyAPI(object):
    def foo(self):
        return "bar"

    def bar(self):
        raise Exception("blah")

class MyServer(Server):
    def prepare_api(self):
        return MyAPI()

    def define_headers(self):
        return { "version": "v1.1" }

if __name__ == '__main__':
    MyServer().start()
```